### PR TITLE
fixes #1: race condition

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -36,11 +36,11 @@ class CognitoExpress {
         this.iss = `https://cognito-idp.${config.region}.amazonaws.com/${this
             .userPoolId}`;
 
-        this.init(callback => {});
+        this.promise = this.init(callback => {});
     }
 
     init(callback) {
-        request(`${this.iss}/.well-known/jwks.json`)
+        return request(`${this.iss}/.well-known/jwks.json`)
             .then(response => {
                 this.pems = {};
                 let keys = JSON.parse(response)["keys"];
@@ -63,39 +63,42 @@ class CognitoExpress {
     }
 
     validate(token, callback) {
-        let decodedJwt = jwt.decode(token, { complete: true });
+        this.promise.then(() => {
+            let decodedJwt = jwt.decode(token, { complete: true });
 
-        if (!decodedJwt) {
-            return callback(`Not a valid JWT token`, null);
-        }
-
-        if (decodedJwt.payload.iss !== this.iss) {
-            return callback(`token is not from your User Pool`, null);
-        }
-
-        if (decodedJwt.payload.token_use !== this.tokenUse) {
-            return callback(`Not an ${this.tokenUse} token`, null);
-        }
-
-        let kid = decodedJwt.header.kid;
-        let pem = this.pems[kid];
-
-        if (!pem) {
-            return callback(`Invalid ${this.tokenUse} token`, null);
-        }
-
-        jwt.verify(
-            token,
-            pem,
-            {
-                issuer: this.iss,
-                maxAge: this.tokenExpiration
-            },
-            function(err, payload) {
-                if (err) return callback(err, null);
-                return callback(null, payload);
+            if (!decodedJwt) {
+                return callback(`Not a valid JWT token`, null);
             }
-        );
+
+            if (decodedJwt.payload.iss !== this.iss) {
+                return callback(`token is not from your User Pool`, null);
+            }
+
+            if (decodedJwt.payload.token_use !== this.tokenUse) {
+                return callback(`Not an ${this.tokenUse} token`, null);
+            }
+
+            let kid = decodedJwt.header.kid;
+            let pem = this.pems[kid];
+
+            if (!pem) {
+                return callback(`Invalid ${this.tokenUse} token`, null);
+            }
+
+            jwt.verify(
+                token,
+                pem,
+                {
+                    issuer: this.iss,
+                    maxAge: this.tokenExpiration
+                },
+                function(err, payload) {
+                    if (err) return callback(err, null);
+                    return callback(null, payload);
+                }
+            );
+        });
+
     }
 }
 


### PR DESCRIPTION
It fails because when you instantiate the `CognitoExpress` object an async request is made. If you call validate before it comes back it fails. this fix wraps the validate method in that async promise function.