### PR TITLE
Remove console.log

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -111,7 +111,6 @@ function jwtVerify(params, callback) {
         },
         function(err, payload) {
             if (err) return callback(err, null);
-            console.log(payload);
             return callback(null, payload);
         }
     );


### PR DESCRIPTION
This console.log causes verbose JSON to be output in the console log. This PR removes it.