### PR TITLE
Fixes `validate()` (and unit tests) when being invoked under the promise metaphor in failure scenarios

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -46,46 +46,48 @@ class CognitoExpress {
     }
 
     validate(token, callback) {
-        const p = this.promise.then(() => {
-            let decodedJwt = jwt.decode(token, { complete: true });
+        // Perform all the validation work using promises and exceptions.
+        const validatePromise = this.promise.then(() => {
+            const decodedJwt = jwt.decode(token, { complete: true });
 
-            if (!decodedJwt) return callback(`Not a valid JWT token`, null);
+            if (!decodedJwt) throw `Not a valid JWT token`;
 
             if (decodedJwt.payload.iss !== this.iss)
-                return callback(`token is not from your User Pool`, null);
+                throw `token is not from your User Pool`;
 
             if (decodedJwt.payload.token_use !== this.tokenUse)
-                return callback(`Not an ${this.tokenUse} token`, null);
+                throw `Not an ${this.tokenUse} token`;
 
-            let kid = decodedJwt.header.kid;
-            let pem = this.pems[kid];
+            const kid = decodedJwt.header.kid;
+            const pem = this.pems[kid];
 
-            if (!pem) return callback(`Invalid ${this.tokenUse} token`, null);
+            if (!pem) throw `Invalid ${this.tokenUse} token`;
 
-            let params = {
+            const params = {
                 token: token,
                 pem: pem,
                 iss: this.iss,
                 maxAge: this.tokenExpiration
             };
 
-            if (callback) {
-                jwtVerify(params, callback);
-            } else {
-                return new Promise((resolve, reject) => {
-                    jwtVerify(params, (err, result) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(result);
-                        }
-                    });
+            return new Promise((resolve, reject) => {
+                jwtVerify(params, (err, result) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(result);
+                    }
                 });
-            }
+            });
         });
-        
-        if (!callback) {
-            return p;
+
+        // Adapt to the callback metaphor if necessary.
+        if (callback) {
+            validatePromise
+                .then(value => callback(undefined, value))
+                .catch(error => callback(error, undefined));
+        } else {
+            return validatePromise;
         }
     }
 }

--- a/test/strategy.js
+++ b/test/strategy.js
@@ -119,14 +119,12 @@ describe("Strategy Positive Scenarios", () => {
 	});
 
 	it("should check if Validate function can fail successfully when invalid token is passed (Promise)", async () => {
-		await strategy.init(async callback => {
-			try {
-				await strategy.validate("token");
-				expect(true).to.eql(false);
-			} catch (err) {
-				expect(err).to.eql("Not a valid JWT token");
-			};
-		});
+		await strategy.init(result => expect(result).to.eql(true));
+		try {
+			await strategy.validate("token");
+		} catch (err) {
+			expect(err).to.eql("Not a valid JWT token");
+		};
 	});
 
 


### PR DESCRIPTION
Fixes #18