### PR TITLE
FIX 'callback is not a funciton' error when running test script.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -48,42 +48,46 @@ class CognitoExpress {
     validate(token, callback) {
         const p = this.promise.then(() => {
             let decodedJwt = jwt.decode(token, { complete: true });
+            try {
+                if (!decodedJwt) throw new TypeError('Not a valid JWT token');
 
-            if (!decodedJwt) return callback(`Not a valid JWT token`, null);
+                if (decodedJwt.payload.iss !== this.iss)
+                    throw new TypeError('token is not from your User Pool');
 
-            if (decodedJwt.payload.iss !== this.iss)
-                return callback(`token is not from your User Pool`, null);
+                if (decodedJwt.payload.token_use !== this.tokenUse)
+                    throw new TypeError(`Not an ${this.tokenUse} token`);
 
-            if (decodedJwt.payload.token_use !== this.tokenUse)
-                return callback(`Not an ${this.tokenUse} token`, null);
+                let kid = decodedJwt.header.kid;
+                let pem = this.pems[kid];
 
-            let kid = decodedJwt.header.kid;
-            let pem = this.pems[kid];
+                if (!pem) throw new TypeError(`Invalid ${this.tokenUse} token`);
 
-            if (!pem) return callback(`Invalid ${this.tokenUse} token`, null);
-
-            let params = {
-                token: token,
-                pem: pem,
-                iss: this.iss,
-                maxAge: this.tokenExpiration
-            };
-
-            if (callback) {
-                jwtVerify(params, callback);
-            } else {
-                return new Promise((resolve, reject) => {
-                    jwtVerify(params, (err, result) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(result);
-                        }
+                let params = {
+                    token: token,
+                    pem: pem,
+                    iss: this.iss,
+                    maxAge: this.tokenExpiration
+                };
+                if (callback) {
+                    jwtVerify(params, callback);
+                } else {
+                    return new Promise((resolve, reject) => {
+                        jwtVerify(params, (err, result) => {
+                            if (err) {
+                                reject(err);
+                            } else {
+                                resolve(result);
+                            }
+                        });
                     });
-                });
+                }
+            } catch(err) {
+                if(!callback) throw err;
+
+                callback(err.message, null);
             }
         });
-        
+
         if (!callback) {
             return p;
         }

--- a/test/strategy.js
+++ b/test/strategy.js
@@ -124,7 +124,8 @@ describe("Strategy Positive Scenarios", () => {
 				await strategy.validate("token");
 				expect(true).to.eql(false);
 			} catch (err) {
-				expect(err).to.eql("Not a valid JWT token");
+				expect(err).to.be.an.instanceof(TypeError);
+				expect(err.message).to.eql("Not a valid JWT token");
 			};
 		});
 	});


### PR DESCRIPTION
When you run `npm run test', it should now pass all the existing
test cases.
In previous commit, it was failing the test because the validate
method was not provided the callback. This made the
callback('Not a valid JWT token', null) to be failed because the
callback variable is undefined.